### PR TITLE
misc - tflint - Specify minimum terraform and aws provider versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.5] - 2023-XX-XX
+
+### Added
+
+- Required minimum version of Terraform to `1.3.3`
+- Required minimum version of `hashicorp/aws` provider to `5.0.0`
+
 ## [0.0.4] - 2023-06-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A Terraform module for managing a multi-AZ ECS application.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.3.3"
+
+  required_providers {
+    aws = {
+      version = "~> 5.0.0"
+      source  = "hashicorp/aws"
+    }
+  }
+}


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Specify minimum terraform and aws provider versions

## Why is this PR being done?
These were pointed out by `tflint` and it may be a good idea to add these for consistency and compatibility.  

## Checklist - These are **not** mandatory

- [ ] I have updated the README.md if there are new procedures or changes.
- [x] I have updated CHANGELOG.md with new changes. 
- [ ] I have deployed this change in another project successfully.

## Optional: Additional Notes

```
➜  terraform-aws-ecs-app git:(misc/fix-tflint-errors) tflint
2 issue(s) found:

Warning: terraform "required_version" attribute is required (terraform_required_version)

  on  line 0:
   (source code not available)

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_version.md

Warning: Missing version constraint for provider "aws" in "required_providers" (terraform_required_providers)

  on security-groups.tf line 44:
  44: data "aws_subnet" "alb_subnets" {

Reference: https://github.com/terraform-linters/tflint-ruleset-terraform/blob/v0.2.2/docs/rules/terraform_required_providers.md
```

❓ - What do you think about these versions?  Should we update to the latest major version?