### PR TITLE
Feature/add http redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.7] - 2023-09-15
+
+### Added
+
+- Added redirect ALB listener.
+
+## [0.0.6] - 2023-08-17
+
+### Changed
+
+- Added write-all permissions to GitHub Action workflow.
+
 ## [0.0.5] - 2023-07-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ No modules.
 |------|------|
 | [aws_alb.alb](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb) | resource |
 | [aws_alb_listener.listener](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_listener) | resource |
+| [aws_alb_listener.listener_for_redirect](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_listener) | resource |
 | [aws_alb_target_group.target_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/alb_target_group) | resource |
 | [aws_cloudwatch_event_rule.ecs_deployment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_target.ecs_deployment_events_sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
@@ -76,6 +77,7 @@ No modules.
 | <a name="input_alb_listener_action_type"></a> [alb\_listener\_action\_type](#input\_alb\_listener\_action\_type) | Type of routing action. Valid values are [forward, redirect, fixed-response, authenticate-cognito and authenticate-oidc] | `string` | `"forward"` | no |
 | <a name="input_alb_listener_certificate_arn"></a> [alb\_listener\_certificate\_arn](#input\_alb\_listener\_certificate\_arn) | ARN of the default SSL server certificate. Exactly one certificate is required if the protocol is HTTPS. | `string` | n/a | yes |
 | <a name="input_alb_listener_ssl_policy"></a> [alb\_listener\_ssl\_policy](#input\_alb\_listener\_ssl\_policy) | Name of the SSL Policy for the listener. | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` | no |
+| <a name="input_alb_redirect_port"></a> [alb\_redirect\_port](#input\_alb\_redirect\_port) | Port for which the ALB will forward to the alb\_ingress\_port.  e.g. HTTP:80 to HTTP:443 redirection. | `number` | `80` | no |
 | <a name="input_alb_stickiness_enabled"></a> [alb\_stickiness\_enabled](#input\_alb\_stickiness\_enabled) | Whether or not stickiness is enabled on the ALB. | `bool` | `true` | no |
 | <a name="input_alb_subnets"></a> [alb\_subnets](#input\_alb\_subnets) | Subnets in which to run the ALB. | `set(string)` | n/a | yes |
 | <a name="input_alb_target_group_deregistration_delay"></a> [alb\_target\_group\_deregistration\_delay](#input\_alb\_target\_group\_deregistration\_delay) | Amount of time for Elastic Load Balancing to wait before changing the state of a deregistering target from draining to unused. The range is 0-3600 seconds. The default value is 300 seconds. | `number` | `0` | no |

--- a/alb.tf
+++ b/alb.tf
@@ -52,3 +52,19 @@ resource "aws_alb_listener" "listener" {
     type             = var.alb_listener_action_type
   }
 }
+
+resource "aws_alb_listener" "listener_for_redirect" {
+  load_balancer_arn = aws_alb.alb.arn
+  port              = var.alb_redirect_port
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      port        = var.alb_ingress_port
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -288,6 +288,12 @@ variable "alb_ingress_port" {
   default     = 443
 }
 
+variable "alb_redirect_port" {
+  type        = number
+  description = "Port for which the ALB will forward to the alb_ingress_port.  e.g. HTTP:80 to HTTP:443 redirection."
+  default     = 80
+}
+
 variable "alb_target_group_target_type" {
   type        = string
   description = "Type of target that you must specify when registering targets with this target group. [instance, ip, lambda, alb]"


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Add listener_for_redirect

## Why is this PR being done?
By default an ALB listener should be included that redirects HTTP:80 to the ingest port, which by default is HTTPS:443.

## Checklist - These are **not** mandatory

- [ ] I have updated the README.md if there are new procedures or changes.
- [x] I have updated CHANGELOG.md with new changes. 
- [ ] I have deployed this change in another project successfully.

## Optional: Additional Notes
