### PR TITLE
Added Ingress/Egress CIDR Block Variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.10] - 2026-01-09
+
+### Changed
+
+- Changed ALB ingress and egress CIDR blocks to use variables instead of set values
+- Variables default to old value (["0.0.0.0/0"])
+
 ## [0.0.9] - 2023-10-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alb_drop_invalid_header_fields"></a> [alb\_drop\_invalid\_header\_fields](#input\_alb\_drop\_invalid\_header\_fields) | Indicates whether HTTP headers with header fields that are not valid are removed by the load balancer (true) or routed to targets (false). Elastic Load Balancing requires that message header names contain only alphanumeric characters and hyphens. | `bool` | `true` | no |
+| <a name="input_alb_egress_cidr_blocks"></a> [alb\_egress\_cidr\_blocks](#input\_alb\_egress\_cidr\_blocks) | Allowed CIDR blocks for ALB egress | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | <a name="input_alb_idle_timeout"></a> [alb\_idle\_timeout](#input\_alb\_idle\_timeout) | The time in seconds that the connection is allowed to be idle. | `number` | `60` | no |
+| <a name="input_alb_ingress_cidr_blocks"></a> [alb\_ingress\_cidr\_blocks](#input\_alb\_ingress\_cidr\_blocks) | Allowed CIDR blocks for ALB ingress | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | <a name="input_alb_ingress_port"></a> [alb\_ingress\_port](#input\_alb\_ingress\_port) | Port for which the ALB listens on to accept traffic and route to the target group. | `number` | `443` | no |
 | <a name="input_alb_internal"></a> [alb\_internal](#input\_alb\_internal) | Whether or not the loab balancer is internal. | `bool` | `false` | no |
 | <a name="input_alb_listener_action_type"></a> [alb\_listener\_action\_type](#input\_alb\_listener\_action\_type) | Type of routing action. Valid values are [forward, redirect, fixed-response, authenticate-cognito and authenticate-oidc] | `string` | `"forward"` | no |
@@ -131,8 +133,6 @@ No modules.
 | <a name="input_sns_topic_subscription_protocol"></a> [sns\_topic\_subscription\_protocol](#input\_sns\_topic\_subscription\_protocol) | The protocol you want to use. Supported protocols include: [email, email-json, http, https, sqs, sms, lambda] | `string` | `"https"` | no |
 | <a name="input_task_policy_actions"></a> [task\_policy\_actions](#input\_task\_policy\_actions) | List of services and their permissions to apply to the policy. | `set(string)` | n/a | yes |
 | <a name="input_task_policy_resources"></a> [task\_policy\_resources](#input\_task\_policy\_resources) | Resources that task\_policy\_actions should be applied to. | `set(string)` | <pre>[<br>  "*"<br>]</pre> | no |
-| <a name="alb_ingress_cidr_blocks"></a> [alb\_ingress\_cidr\_blocks](#alb\_ingress\_cidr\_blocks) | Allowed CIDR blocks for ALB ingress (default ["0.0.0.0/0"]) | `list(string)` | `["0.0.0.0/0"]` | no |
-| <a name="alb_egress_cidr_blocks"></a> [alb\_egress\_cidr\_blocks](#alb\_egress\_cidr\_blocks) | Allowed CIDR blocks for ALB egress (default ["0.0.0.0/0"]) | `list(string)` | `["0.0.0.0/0"]` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ No modules.
 | <a name="input_sns_topic_subscription_protocol"></a> [sns\_topic\_subscription\_protocol](#input\_sns\_topic\_subscription\_protocol) | The protocol you want to use. Supported protocols include: [email, email-json, http, https, sqs, sms, lambda] | `string` | `"https"` | no |
 | <a name="input_task_policy_actions"></a> [task\_policy\_actions](#input\_task\_policy\_actions) | List of services and their permissions to apply to the policy. | `set(string)` | n/a | yes |
 | <a name="input_task_policy_resources"></a> [task\_policy\_resources](#input\_task\_policy\_resources) | Resources that task\_policy\_actions should be applied to. | `set(string)` | <pre>[<br>  "*"<br>]</pre> | no |
+| <a name="alb_ingress_cidr_blocks"></a> [alb\_ingress\_cidr\_blocks](#alb\_ingress\_cidr\_blocks) | Allowed CIDR blocks for ALB ingress (default ["0.0.0.0/0"]) | `list(string)` | `["0.0.0.0/0"]` | no |
+| <a name="alb_egress_cidr_blocks"></a> [alb\_egress\_cidr\_blocks](#alb\_egress\_cidr\_blocks) | Allowed CIDR blocks for ALB egress (default ["0.0.0.0/0"]) | `list(string)` | `["0.0.0.0/0"]` | no |
 
 ## Outputs
 

--- a/security-groups.tf
+++ b/security-groups.tf
@@ -4,26 +4,26 @@ resource "aws_security_group" "alb" {
   vpc_id      = local.actual_alb_vpc_id
 
   ingress {
-    description = "Allow traffic from the internet on ${var.alb_ingress_port}"
+    description = "Allow traffic on ${var.alb_ingress_port}"
     protocol    = "tcp"
     from_port   = var.alb_ingress_port
     to_port     = var.alb_ingress_port
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.alb_ingress_cidr_blocks
   }
 
   ingress {
-    description = "Allow traffic from the internet on ${var.alb_redirect_port}"
+    description = "Allow traffic on ${var.alb_redirect_port}"
     protocol    = "tcp"
     from_port   = var.alb_redirect_port
     to_port     = var.alb_redirect_port
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.alb_ingress_cidr_blocks
   }
 
   egress {
     protocol    = "-1"
     from_port   = 0
     to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = var.alb_egress_cidr_blocks
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -373,3 +373,16 @@ variable "container_secrets" {
   description = "The secrets from AWS Secrets Manager to pass to a container."
   default     = []
 }
+
+### SECURITY GROUPS ###
+variable "alb_ingress_cidr_blocks" {
+  description = "Allowed CIDR blocks for ALB ingress"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
+variable "alb_egress_cidr_blocks" {
+  description = "Allowed CIDR blocks for ALB egress"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}


### PR DESCRIPTION
swapped out hardcoded CIDR blocks for ALB SG for variables, default value fallsback to original value for backwards compatibility

# Pull Request

## What does this PR do?
changes from hardcoded CIDR values in ALB SG to accept variables 

## Why is this PR being done?
to allow for a ALB to not be publicly available

## Checklist - These are **not** mandatory

- [X ] I have updated the README.md if there are new procedures or changes.
- [X] I have updated CHANGELOG.md with new changes. 
- [X] I have deployed this change in another project successfully.

## Optional: Additional Notes
Tested in TOL's project, CIDR blocks unchanged (as expected)
